### PR TITLE
Couple of patches that should improve situation on 64-bit machines

### DIFF
--- a/Random123.cabal
+++ b/Random123.cabal
@@ -43,6 +43,7 @@ Library
   Build-Depends:
     base >= 4.7.0.0 && < 5.0,
     array >= 0.4,
+    data-dword,
     random >= 1.0.0.0
 
 Test-Suite test
@@ -67,6 +68,6 @@ Benchmark test_perf
   Build-depends:
     base >= 4.4 && < 5.0,
     random >= 1.0,
-    criterion >= 0.6,
+    criterion >= 0.6 && < 1.0,
     Random123
   Ghc-options: -O2

--- a/System/Random/Random123/Philox.hs
+++ b/System/Random/Random123/Philox.hs
@@ -9,6 +9,8 @@ module System.Random.Random123.Philox (
 import Data.Word
 import Data.Bits
 
+import Data.DoubleWord
+
 import System.Random.Random123.Misc
 import System.Random.Random123.Types
 
@@ -43,10 +45,10 @@ instance PhiloxWord Word32 where
 
 instance PhiloxWord Word64 where
     mulhilo a b = (hi, lo) where
-        r :: Integer
-        r = fromIntegral a * fromIntegral b
-        hi = fromIntegral (r `shiftR` 64)
-        lo = fromIntegral r
+        r :: Word128
+        r = extendLo a * extendLo b
+        hi = hiWord r
+        lo = loWord r
 
     philoxW_0 = 0x9E3779B97F4A7C15 -- golden ratio
     philoxW_1 = 0xBB67AE8584CAA73B -- sqrt(3)-1

--- a/System/Random/Random123/RandomGen.hs
+++ b/System/Random/Random123/RandomGen.hs
@@ -20,6 +20,7 @@ module System.Random.Random123.RandomGen (
 
 import System.Random
 import Data.Word
+import Data.Bits
 
 import System.Random.Random123.Types
 import System.Random.Random123.Philox
@@ -55,7 +56,9 @@ next32 bijection ctr wctr = (fromIntegral w32, ctr', wctr') where
         else (increment ctr, 0)
 
 genRange32 :: (Int, Int)
-genRange32 = (0, min maxBound (2^32 - 1))
+genRange32
+    | finiteBitSize (0 :: Int) > 32 = (0, 2^32 - 1)
+    | otherwise                     = (minBound, maxBound)
 
 next64 :: (Counter c, Word64Array c) => (c -> c) -> c -> Int -> (Int, c, Int)
 next64 bijection ctr wctr = (fromIntegral w64, ctr', wctr') where
@@ -66,7 +69,9 @@ next64 bijection ctr wctr = (fromIntegral w64, ctr', wctr') where
         else (increment ctr, 0)
 
 genRange64 :: (Int, Int)
-genRange64 = (0, min maxBound (2^64 - 1))
+genRange64
+    | finiteBitSize (0 :: Int) > 64 = (0, 2^64 - 1)
+    | otherwise                     = (minBound, maxBound)
 
 
 instance (Counter c, Word32Array c) => RandomGen (CustomCBRNG32 k c) where


### PR DESCRIPTION
On 64-bit machines `genRange64` was returning `(0, -1)` - fixed this and `genRange32` too for consistency.

Additionally, I have replaced intermediate `Integer` in `PhiloxWord Word64` instance with `Word128` from `data-dword` package. This almost doubled bijection performance.
